### PR TITLE
fix issue with deleting cohorts in TARGET with high number of records

### DIFF
--- a/client.py
+++ b/client.py
@@ -76,16 +76,17 @@ class Client:
             "}"
         "")
 
-        variables =  {'pkey': pkey}
+        stepSize = 1000 # to make sure list is not to big which will make server give error 500
 
-        response = self.session.post(
-            self.graphqlEndpoint,
-            json={'query': query, 'variables': variables}
-        )
-
-        if response.status_code != 200:
-            log.error(response)
-            log.error(f"Error uploading csv, response.text: {response.text}")
+        for i in range(0, len(pkey), stepSize):
+            variables =  {'pkey': pkey[i:i+stepSize]}
+            response = self.session.post(
+                self.graphqlEndpoint,
+                json={'query': query, 'variables': variables}
+            )
+            if response.status_code != 200:
+                log.error(response)
+                log.error(f"Error uploading csv, response.text: {response.text}")
 
         return response
 


### PR DESCRIPTION
This fixes an issue when we try to migrate cohorts to datacatalogue where the cohorts has a high number of (for example) 5000+ VariableMappings. This resulted in a server 500 error.
The hardcoded stepSize is just a guess, 4200 works in all cases but set to 1000.
